### PR TITLE
Api fix 422 status code

### DIFF
--- a/Minitwit-api/minitwit_api_2.py
+++ b/Minitwit-api/minitwit_api_2.py
@@ -123,7 +123,7 @@ def get_latest() -> dict[str, int]:
 
 
 @app.get("/msgs", status_code=200)
-def get_messages(request: Request, latest: int, no: int = LIMIT) -> list[Tweet]:
+def get_messages(request: Request, latest: int = -1, no: int = LIMIT) -> list[Tweet]:
     """Returns the latest messages"""
     update_latest(latest)
     authenticate_simulator(request)
@@ -143,7 +143,9 @@ def get_messages(request: Request, latest: int, no: int = LIMIT) -> list[Tweet]:
 
 
 @app.get("/msgs/{username}", status_code=200)
-def get_user_messages(request: Request, username: str, latest: int, no: int = LIMIT) -> list[Tweet]:
+def get_user_messages(
+    request: Request, username: str, latest: int = -1, no: int = LIMIT
+) -> list[Tweet]:
     """Returns the latest messages of a given user"""
     update_latest(latest)
     authenticate_simulator(request)
@@ -166,7 +168,7 @@ def get_user_messages(request: Request, username: str, latest: int, no: int = LI
 
 @app.get("/fllws/{username}", status_code=200)
 def get_user_followers(
-    request: Request, username: str, latest: int, no: int = LIMIT
+    request: Request, username: str, latest: int = -1, no: int = LIMIT
 ) -> dict[str, list[str]]:
     """Returns followers of a given user"""
     update_latest(latest)
@@ -193,7 +195,7 @@ POST ENDPOINTS
 
 
 @app.post("/register", status_code=204)
-def post_register_user(latest: int, user: User) -> None:
+def post_register_user(user: User, latest: int = -1) -> None:
     update_latest(latest)
     if get_user_id(user.username) is not None:
         raise HTTPException(status_code=400, detail="The username is already taken")
@@ -218,7 +220,7 @@ def post_register_user(latest: int, user: User) -> None:
 
 
 @app.post("/msgs/{username}", status_code=204)
-def post_user_messages(request: Request, username: str, latest: int, message: Message) -> None:
+def post_user_messages(request: Request, username: str, message: Message, latest: int = -1) -> None:
     """Posts message as a given user"""
     update_latest(latest)
     authenticate_simulator(request)
@@ -234,7 +236,7 @@ def post_user_messages(request: Request, username: str, latest: int, message: Me
 
 @app.post("/fllws/{username}", status_code=204)
 def post_follow_unfollow_user(
-    request: Request, username: str, latest: int, f_u: Follow_Unfollow
+    request: Request, username: str, f_u: Follow_Unfollow, latest: int = -1
 ) -> None:
     """Follows or unfollows user for another given user"""
     update_latest(latest)

--- a/Minitwit-api/msgs_test.py
+++ b/Minitwit-api/msgs_test.py
@@ -1,0 +1,28 @@
+import requests
+import base64
+
+
+# API in droplet
+HOST = "http://138.68.73.127:8080"
+
+# API in local container
+# HOST = "http://localhost:8080"
+USERNAME = "simulator"
+PWD = "super_safe!"
+CREDENTIALS = ":".join([USERNAME, PWD]).encode("ascii")
+ENCODED_CREDENTIALS = base64.b64encode(CREDENTIALS).decode()
+HEADERS = {
+    "Connection": "close",
+    "Content-Type": "application/json",
+    f"Authorization": f"Basic {ENCODED_CREDENTIALS}",
+}
+
+
+def get_10_messages():
+    url = f"{HOST}/msgs"
+    response = requests.get(url, params={"no": 1}, headers=HEADERS)
+    print(f"Status code: {response.status_code}")
+    print(f"Content: {response.text}")
+
+
+get_10_messages()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
-# Passwords are explicit, for tests only, do not use for production :)
+# THIS IS A LOCAL 'docker-compose' FILE FOR LOCAL BUILDS AND TESTS
 version: '3'
 services:
   postgres:
-    image: ${DOCKER_USERNAME}/minitwitdb
+    build: ./Database
     container_name: DB-postgres
     restart: always
     volumes:
@@ -21,14 +21,15 @@ services:
       - 8082:8080
 
   api:
-    image: ${DOCKER_USERNAME}/apiminitwit
+    build: ./Minitwit-api
     container_name: API
     depends_on:
       - postgres
     ports:
       - 8080:8080
+
   app:
-    image: ${DOCKER_USERNAME}/minitwitimage
+    build: ./ITU_MiniTwit
     container_name: APP
     command: >
       sh -c "


### PR DESCRIPTION
### Bug
Status code 422 that can be seen on the last dashboard on http://104.248.134.203/status.html

### Fix
- I reproduced that issue with script that I committed on this branch
- The issue was caused by API requirement to provide the 'latest' value
- Request to /msgs endpoint didn't contain it and resulted in 422 response: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422
- I checked the API specification and it shouldn't require 'latest' value
- Default value for 'latest' when it is not provided is -1
- I modified the docker-compose file in the main directory to use it for local builds and tests
- I didn't modify docker-compose file in the remote files directory