### PR TITLE
Cursed grafana

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,8 @@ services:
   grafana:
     build: ./grafana
     container_name: grafana
+    volumes:
+      - grafana_volume:/var/lib/grafana
     ports:
       - 5003:3000
     networks:
@@ -108,6 +110,7 @@ volumes:
   postgres_volume:
   elk-elasticsearch-volume:
   prometheus_volume:
+  grafana_volume:
 
 
 networks:

--- a/remote_files/docker-compose.yml
+++ b/remote_files/docker-compose.yml
@@ -58,13 +58,16 @@ services:
   prometheus:
     image: ${DOCKER_USERNAME}/prometheus:latest
     container_name: prometheus
+    volumes:
+      - prometheus_volume:/prometheus
     networks:
       - main
-
 
   grafana:
     image: ${DOCKER_USERNAME}/grafana:latest
     container_name: grafana
+    volumes:
+      - grafana_volume:/var/lib/grafana
     ports:
       - "5003:3000"
     networks:
@@ -73,29 +76,29 @@ services:
   elasticsearch:
     image: "docker.elastic.co/elasticsearch/elasticsearch:7.17.1"
     environment:
-        - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
-        - "discovery.type=single-node"
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+      - "discovery.type=single-node"
     volumes:
-        - elk-elasticsearch-volume:/usr/share/elasticsearch/data
+      - elk-elasticsearch-volume:/usr/share/elasticsearch/data
     networks:
-        - elk
+      - elk
 
   kibana:
     image: "docker.elastic.co/kibana/kibana:7.17.1"
     environment:
-        elasticsearch.hosts: '["http://elasticsearch:9200"]'
+      elasticsearch.hosts: '["http://elasticsearch:9200"]'
     networks:
-        - elk
+      - elk
 
   filebeat:
     image: ${DOCKER_USERNAME}/filebeat:latest
     volumes:
-        - /var/lib/docker:/var/lib/docker:ro
-        - /var/run/docker.sock:/var/run/docker.sock
+      - /var/lib/docker:/var/lib/docker:ro
+      - /var/run/docker.sock:/var/run/docker.sock
     networks:
-        - elk
-          
-  nginx: 
+      - elk
+
+  nginx:
     image: ${DOCKER_USERNAME}/nginx:latest
     ports:
       - 9200:9200
@@ -106,6 +109,9 @@ services:
 volumes:
   postgres_volume:
   elk-elasticsearch-volume:
+  prometheus_volume:
+  grafana_volume:
+
 
 networks:
   main:


### PR DESCRIPTION
- Hardcoded passwords rip [*]
- Metrics that are needed for Grafana dashboards are saved on Prometheus volume
- Grafana also got its own volume just in case, because it's freaky